### PR TITLE
Add `defn-traced` macro using the OpenTracing API

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,4 @@
+steps:
+- label: "Test"
+  commands:
+  - lein test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+## Leiningen defaults
+
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- `defn-traced` macro

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# opentracing-compat
+
+A compatibility layer bridging [`defn-traced`][github-clj-newrelic] with the
+OpenTracing API.
+
+## Quick start
+
+Use it just like [`defn-traced`][github-clj-newrelic]:
+
+```clojure
+(ns user
+  (:require [democracyworks.opentracing.compat :refer [defn-traced]]))
+
+(defn-traced sleep-for
+  "Sleep for `x` milliseconds."
+  [x]
+  (Thread/sleep x))
+```
+
+## License
+
+Copyright 2019 Democracy Works, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.  You may obtain a copy of the
+License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations under the License.
+
+[github-clj-newrelic]: https://github.com/TheClimateCorporation/clj-newrelic

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,9 @@
+(defproject democracyworks/opentracing-compat "0.1.0-SNAPSHOT"
+  :description "A compatibility library bridging clj-newrelic with the OpenTracing API."
+  :license {:name "Apache License 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0.html"
+            :distribution :repo}
+  :url "https://github.com/democracyworks/opentracing-compat"
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [opentracing-clj "0.1.4"]]
+  :profiles {:dev {:dependencies [[io.opentracing/opentracing-mock "0.32.0"]]}})

--- a/src/democracyworks/opentracing/compat.clj
+++ b/src/democracyworks/opentracing/compat.clj
@@ -1,0 +1,71 @@
+(ns democracyworks.opentracing.compat
+  "OpenTracing functionality compatible with [clj-newrelic].
+
+  [clj-newrelic]: https://github.com/TheClimateCorporation/clj-newrelic"
+  (:require [clojure.core.specs.alpha :as specs]
+            [clojure.spec.alpha :as s]
+            [opentracing-clj.core :as tracing]))
+
+(defn- instrument-body
+  "Start an OpenTracing span on the `body` in `forms` and return the transformed
+  forms as a list.
+
+  Designed to be called on either `defn` forms directly for single-arity
+  functions or on the arity definition lists for multi-arity functions."
+  [forms span-name body]
+  (let [split-index (- (count forms) (count body))
+        [first-forms last-forms] (split-at split-index forms)
+        s (gensym)]
+    `(~@first-forms
+      (tracing/with-span [~s {:name ~span-name}]
+        ~@last-forms))))
+
+(defn- extract-fn-body
+  "Pull the function body forms out of the `conformed` body."
+  [conformed]
+  (let [body (second conformed)]
+    (if (map? body)
+      (:body body)
+      body)))
+
+(defmacro defn-traced
+  "Like `defn`, but wraps the function body in an OpenTracing span that mimics
+  the default behavior of the `clj-newrelic` `defn-traced` macro.
+
+  Nesting calls to `defn-traced` works similarly to the default behavior of the
+  `defn-traced` macro that it replaces: nested spans will be set as children of
+  unfinished spans.
+
+  This macro is a transitional drop-in replacement for `defn-traced`, so if you
+  need more control over the tracing behavior you should manipulate spans
+  directly."
+  [& args]
+  (let [[fname body] ((juxt first rest) args)
+        span-name (str *ns* \. fname)
+        conformed-args (s/conform ::specs/defn-args args)
+        [arity-n tail] (:fn-tail conformed-args)]
+    (case arity-n
+      :arity-1
+      `(defn ~fname
+         ~@(instrument-body body span-name (extract-fn-body (:body tail))))
+
+      :arity-n
+      (let [[first-forms arities last-forms] (partition-by list? args)]
+        `(defn
+           ~@first-forms
+           ~@(map-indexed
+              (fn [idx arity]
+                (instrument-body
+                 arity
+                 span-name
+                 (extract-fn-body (second (second (nth (:bodies tail) idx))))))
+              arities)
+           ~@(seq last-forms)))
+
+      ;; Default to bog standard `defn` if we can't figure out the arity for
+      ;; some reason, or maybe for "forward compatibility".
+      `(defn ~fname ~@body))))
+
+(s/fdef defn-traced
+  :args ::specs/defn-args
+  :ret any?)

--- a/test/democracyworks/opentracing/compat_test.clj
+++ b/test/democracyworks/opentracing/compat_test.clj
@@ -1,0 +1,57 @@
+(ns democracyworks.opentracing.compat-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [democracyworks.opentracing.compat :refer [defn-traced]]
+            [opentracing-clj.core :as tracing])
+  (:import (io.opentracing.mock MockTracer)))
+
+(defn-traced child
+  []
+  (apply + (range 10)))
+
+(defn-traced parent
+  []
+  (child))
+
+(defn-traced multi-arity
+  "This one has a docstring."
+  ([]
+   (multi-arity 42))
+  ([x]
+   {:pre [(= x 42)]}
+   (apply + (range x))))
+
+(defn untraced
+  []
+  (apply + (range 10)))
+
+(deftest defn-traced-test
+  (testing "calling child on its own creates a single root span"
+    (binding [tracing/*tracer* (MockTracer.)]
+      (is (= 45 (child)))
+      (is (= 1 (count (.finishedSpans tracing/*tracer*))))
+      (is (zero? (.parentId (first (.finishedSpans tracing/*tracer*))))
+          "the parentId should be zero for root spans")))
+  (testing "parent and child create two spans with a parent/child relationship"
+    ;; Spans are appended in order of finishing, so the child should finish
+    ;; first and have a non-zero parent ID, then the parent will finish and
+    ;; should have a parent ID of zero since it is the root span.
+    (binding [tracing/*tracer* (MockTracer.)]
+      (is (= 45 (parent)))
+      (is (= 2 (count (.finishedSpans tracing/*tracer*))))
+      (is (pos? (.parentId (first (.finishedSpans tracing/*tracer*))))
+          "the child span has a non-zero parent ID")
+      (is (zero? (.parentId (second (.finishedSpans tracing/*tracer*))))
+          "the parent span has a parent ID of 0 (is the root span)")))
+  (testing "multi-arity functions work as expected"
+    (binding [tracing/*tracer* (MockTracer.)]
+      (is (= 861 (multi-arity)))
+      (is (= "This one has a docstring." (:doc (meta #'multi-arity))))
+      (is (= 2 (count (.finishedSpans tracing/*tracer*))))
+      (is (pos? (.parentId (first (.finishedSpans tracing/*tracer*))))
+          "the child span has a non-zero parent ID")
+      (is (zero? (.parentId (second (.finishedSpans tracing/*tracer*))))
+          "the parent span has a parent ID of 0 (is the root span)")))
+  (testing "untraced function creates no spans"
+    (binding [tracing/*tracer* (MockTracer.)]
+      (is (= 45 (untraced)))
+      (is (zero? (count (.finishedSpans tracing/*tracer*)))))))


### PR DESCRIPTION
* Created initial project scaffolding
* Added tests to ensure spans are created similarly to the `defn-traced` that
  interacted with the New Relic API.